### PR TITLE
fixed bug

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1099,7 +1099,7 @@ $(".settingsUI[for=accountPassword] input")
 	});
 
 function ratingToClass(x) {
-	if (x == undefined) return "user-unrated";
+	if (x == undefined || isNaN(x)) return "user-unrated";
 	if (x <= 0) return "user-unrated";
 	if (x < 1200) return "user-newbie";
 	if (x < 1400) return "user-pupil";
@@ -1114,7 +1114,7 @@ function ratingToClass(x) {
 }
 
 function ratingToSmalln(x) {
-	if (x == undefined) return "U";
+	if (x == undefined || isNaN(x)) return "U";
 	if (x <= 0) return "U";
 	if (x < 1200) return "N";
 	if (x < 1400) return "P";
@@ -1129,7 +1129,7 @@ function ratingToSmalln(x) {
 }
 
 function ratingToGrade(x) {
-	if (x == undefined) return "Unrated";
+	if (x == undefined || isNaN(x)) return "Unrated";
 	if (x <= 0) return "Unrated";
 	if (x < 1200) return "Newbie";
 	if (x < 1400) return "Pupil";


### PR DESCRIPTION
现在用户unr时网页上根本不会显示用户rating，进而导致用户rating=Number(undefined)=NaN，而不是undefined。因此，unrated用户在打第一场比赛的时候在榜单界面点击他显示的名字颜色是LGM的。

我因为不清楚获取用户rating是在哪里获取的，所以只好改rating转换成名字等级的判断……

话说回来这东西真的还在更吗？